### PR TITLE
compatibility with non-json XHRs

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -71,9 +71,7 @@ define([
       // send AJAX request, catch success or error callback
       $.ajax({
           url: url,
-          dataType: "json",
-          contentType: "application/json",
-          data: JSON.stringify(param),
+          data: param,
           headers: header,
           type: type.toUpperCase(),
           success: displaySuccess,


### PR DESCRIPTION
Don't force the body of the request to be JSON otherwise a custom @apiHeader Content-Type header on a request is useless.
Same point for the "stringification" of the body request: don't do that, jQuery is smart and can auto handle the body regards to the Content-Type header.
